### PR TITLE
Python 3 support

### DIFF
--- a/ever2simple/converter.py
+++ b/ever2simple/converter.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 from csv import DictWriter
-from cStringIO import StringIO
+from io import StringIO
 from dateutil.parser import parse
 from html2text import HTML2Text
 from lxml import etree
@@ -30,9 +30,9 @@ class EverConverter(object):
         try:
             parser = etree.XMLParser(huge_tree=True)
             xml_tree = etree.parse(enex_file, parser)
-        except (etree.XMLSyntaxError, ), e:
-            print 'Could not parse XML'
-            print e
+        except etree.XMLSyntaxError as e:
+            print('Could not parse XML')
+            print(e)
             sys.exit(1)
         return xml_tree
 
@@ -73,7 +73,7 @@ class EverConverter(object):
 
     def convert(self):
         if not os.path.exists(self.enex_filename):
-            print "File does not exist: %s" % self.enex_filename
+            print("File does not exist: %s" % self.enex_filename)
             sys.exit(1)
         # TODO: use with here, but pyflakes barfs on it
         enex_file = open(self.enex_filename)
@@ -118,7 +118,7 @@ class EverConverter(object):
             sys.stdout.write(json.dumps(notes))
         else:
             if os.path.exists(self.simple_filename) and not os.path.isdir(self.simple_filename):
-                print '"%s" exists but is not a directory. %s' % self.simple_filename
+                print('"%s" exists but is not a directory. %s' % self.simple_filename)
                 sys.exit(1)
             elif not os.path.exists(self.simple_filename):
                 os.makedirs(self.simple_filename)

--- a/ever2simple/core.py
+++ b/ever2simple/core.py
@@ -27,7 +27,7 @@ def main():
     args = parser.parse_args()
     filepath = os.path.expanduser(args.enex_file)
     if not os.path.exists(filepath):
-        print 'File does not exist: {}'.format(filepath)
+        print('File does not exist: {}'.format(filepath))
         sys.exit(1)
     converter = EverConverter(filepath, args.output, args.format, args.metadata)
     converter.convert()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'lxml',
-        'python-dateutil<2.0',
+        'python-dateutil',
         'html2text',
     ],
     entry_points="""


### PR DESCRIPTION
See claytron/ever2simple#20

The fixes were pretty easy...just follow the stack traces and look up the syntax differences. (I also had a friend who recently did Python 2 to 3 conversions whom I could pester.) Wanted to get this working for my own purposes (moving from Evernote to Turtl).